### PR TITLE
Remove unused page routes

### DIFF
--- a/src/app/fitnutri/lp-principal/page.tsx
+++ b/src/app/fitnutri/lp-principal/page.tsx
@@ -1,2 +1,0 @@
-import LandingPage from '@/components/LandingPage'; import { LandingPageData } from '@/types/lp-config'; import lpData from './lp.json';  const config = lpData as LandingPageData;  export default function FitNutriPage() {   return <LandingPage data={config} />; }
-

--- a/src/app/unico-digital/lp-principal/page.tsx
+++ b/src/app/unico-digital/lp-principal/page.tsx
@@ -1,9 +1,0 @@
-import LandingPage from '@/components/LandingPage';
-import { LandingPageData } from '@/types/lp-config';
-import lpData from './lp.json';
-
-const config = lpData as LandingPageData;
-
-export default function UnicosDigitalPrincipalPage() {
-  return <LandingPage data={config} />;
-}


### PR DESCRIPTION
## Summary
- remove obsolete FitNutri and Unico Digital landing pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688438dbf7c8832998ee183d91a495ff