### PR TITLE
feat: add admin pages

### DIFF
--- a/src/app/admin/(protected)/dashboard/page.tsx
+++ b/src/app/admin/(protected)/dashboard/page.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useAdminAuth } from '@/hooks/useAdminAuth'
+import { DatabaseService } from '@/services/database.service'
+import type { Database } from '@/types/database'
+
+type AccountWithPlan = Database['public']['Tables']['accounts']['Row'] & {
+  plan: Database['public']['Tables']['plans']['Row']
+}
+
+export default function AdminDashboard() {
+  const { isAdmin, isSuperAdmin } = useAdminAuth()
+  const [accounts, setAccounts] = useState<AccountWithPlan[]>([])
+  const [loading, setLoading] = useState(true)
+  const [filter, setFilter] = useState('')
+
+  useEffect(() => {
+    fetchAccounts()
+  }, [])
+
+  const fetchAccounts = async () => {
+    try {
+      setLoading(true)
+      const data = await DatabaseService.getAccounts()
+      setAccounts(data as AccountWithPlan[])
+    } catch (error) {
+      console.error('Erro ao buscar contas:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleToggleLP = async (accountId: string, lpId: string, currentStatus: boolean) => {
+    if (!isSuperAdmin) {
+      alert('Apenas super administradores podem alterar o status das LPs')
+      return
+    }
+
+    try {
+      await DatabaseService.updateLP(lpId, { active: !currentStatus })
+      // Recarregar dados
+      fetchAccounts()
+    } catch (error) {
+      console.error('Erro ao atualizar LP:', error)
+      alert('Erro ao atualizar status da LP')
+    }
+  }
+
+  const filteredAccounts = accounts.filter(
+    account => 
+      account.name.toLowerCase().includes(filter.toLowerCase()) ||
+      account.email.toLowerCase().includes(filter.toLowerCase())
+  )
+
+  return (
+    <div className="px-4 sm:px-0">
+      <div className="sm:flex sm:items-center">
+        <div className="sm:flex-auto">
+          <h1 className="text-2xl font-semibold text-gray-900">
+            Dashboard Administrativo
+          </h1>
+          <p className="mt-2 text-sm text-gray-700">
+            Gerencie clientes e suas Landing Pages
+          </p>
+        </div>
+      </div>
+
+      {/* Filtro */}
+      <div className="mt-6">
+        <input
+          type="text"
+          placeholder="Filtrar por nome ou email..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          className="block w-full rounded-md border-gray-300 shadow-sm focus:border-orange-500 focus:ring-orange-500 sm:text-sm"
+        />
+      </div>
+
+      {/* Lista de Clientes */}
+      <div className="mt-8 flow-root">
+        <div className="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+          <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+            <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
+              <table className="min-w-full divide-y divide-gray-300">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                      Cliente
+                    </th>
+                    <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                      Email
+                    </th>
+                    <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                      Plano
+                    </th>
+                    <th className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                      Landing Pages
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200 bg-white">
+                  {loading ? (
+                    <tr>
+                      <td colSpan={4} className="text-center py-4">
+                        Carregando...
+                      </td>
+                    </tr>
+                  ) : filteredAccounts.length === 0 ? (
+                    <tr>
+                      <td colSpan={4} className="text-center py-4 text-gray-500">
+                        Nenhum cliente encontrado
+                      </td>
+                    </tr>
+                  ) : (
+                    filteredAccounts.map((account) => (
+                      <tr key={account.id}>
+                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-900">
+                          {account.name}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                          {account.email}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                          {account.plan?.name || 'N/A'}
+                        </td>
+                        <td className="px-3 py-4 text-sm text-gray-500">
+                          <div className="text-xs text-gray-400 mb-2">
+                            {/* Aqui viria a lista de LPs quando implementarmos a relação */}
+                            Em breve: lista de LPs
+                          </div>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/admin/(protected)/layout.tsx
+++ b/src/app/admin/(protected)/layout.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useAdminAuth } from '@/hooks/useAdminAuth'
+import { useAuth } from '@/hooks/useAuth'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const { loading } = useAdminAuth()
+  const { signOut } = useAuth()
+  const pathname = usePathname()
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange-600 mx-auto"></div>
+          <p className="mt-4 text-gray-600">Carregando...</p>
+        </div>
+      </div>
+    )
+  }
+
+  const menuItems = [
+    { href: '/admin/dashboard', label: 'Dashboard' },
+    { href: '/admin/clients', label: 'Clientes' },
+    { href: '/admin/lps', label: 'Landing Pages' },
+    { href: '/admin/analytics', label: 'Analytics' },
+  ]
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      {/* Header */}
+      <header className="bg-white shadow-sm">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center py-4">
+            <div className="flex items-center">
+              <h1 className="text-2xl font-bold text-gray-900">
+                LP Factory Admin
+              </h1>
+            </div>
+            <button
+              onClick={signOut}
+              className="text-sm text-gray-500 hover:text-gray-700"
+            >
+              Sair
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {/* Navigation */}
+      <nav className="bg-orange-600">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex space-x-8">
+            {menuItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`py-4 px-1 border-b-2 text-sm font-medium ${
+                  pathname === item.href
+                    ? 'border-white text-white'
+                    : 'border-transparent text-orange-100 hover:text-white hover:border-orange-300'
+                }`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </nav>
+
+      {/* Main Content */}
+      <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+        {children}
+      </main>
+    </div>
+  )
+}
+

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/hooks/useAuth'
+
+export default function AdminLoginPage() {
+  const router = useRouter()
+  const { signIn } = useAuth()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setLoading(true)
+
+    try {
+      const { error } = await signIn(email, password)
+      
+      if (error) {
+        setError('Email ou senha inválidos')
+        return
+      }
+
+      // Redirecionar para dashboard após login bem-sucedido
+      router.push('/admin/dashboard')
+    } catch (err) {
+      setError('Erro ao fazer login. Tente novamente.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-bold text-gray-900">
+            Acesso Administrativo
+          </h2>
+          <p className="mt-2 text-center text-sm text-gray-600">
+            Entre com suas credenciais de administrador
+          </p>
+        </div>
+        
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+          <div className="rounded-md shadow-sm -space-y-px">
+            <div>
+              <label htmlFor="email" className="sr-only">
+                Email
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-orange-500 focus:border-orange-500 focus:z-10 sm:text-sm"
+                placeholder="Email"
+              />
+            </div>
+            <div>
+              <label htmlFor="password" className="sr-only">
+                Senha
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-orange-500 focus:border-orange-500 focus:z-10 sm:text-sm"
+                placeholder="Senha"
+              />
+            </div>
+          </div>
+
+          {error && (
+            <div className="rounded-md bg-red-50 p-4">
+              <div className="text-sm text-red-800">{error}</div>
+            </div>
+          )}
+
+          <div>
+            <button
+              type="submit"
+              disabled={loading}
+              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-orange-600 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? 'Entrando...' : 'Entrar'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+

--- a/src/app/unauthorized/page.tsx
+++ b/src/app/unauthorized/page.tsx
@@ -1,0 +1,18 @@
+export default function UnauthorizedPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="max-w-md w-full text-center">
+        <h1 className="text-4xl font-bold text-gray-900 mb-4">403</h1>
+        <p className="text-xl text-gray-600 mb-8">
+          Você não tem permissão para acessar esta página
+        </p>
+        <a
+          href="/"
+          className="inline-block px-6 py-3 bg-orange-600 text-white rounded-md hover:bg-orange-700"
+        >
+          Voltar ao início
+        </a>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add admin login page
- add admin layout with navigation
- add admin dashboard for managing accounts
- add unauthorized page

## Testing
- `npm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a58beb0988329804993740e203b9a