### PR TITLE
Add dynamic landing page rendering

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -1,0 +1,89 @@
+import { notFound } from 'next/navigation'
+import { DatabaseService } from '@/services/database.service'
+import { RenderSection } from '@/components/RenderSection'
+import { TrackingHead } from '@/components/TrackingHead'
+import type { Database } from '@/types/database'
+
+type LPWithDetails = Database['public']['Tables']['lps']['Row'] & {
+  account: Database['public']['Tables']['accounts']['Row']
+  sections: Database['public']['Tables']['lp_sections']['Row'][]
+}
+
+interface PageProps {
+  params: {
+    slug: string
+  }
+}
+
+export default async function LandingPage({ params }: PageProps) {
+  const lp = await getLPBySlug(params.slug)
+
+  if (!lp) {
+    notFound()
+  }
+
+  // Buscar configurações de tracking
+  const trackingConfig = await DatabaseService.getTrackingConfig(lp.account_id)
+  const conversionTags = await DatabaseService.getConversionTags(lp.id)
+
+  return (
+    <>
+      <TrackingHead
+        trackingConfig={trackingConfig}
+        conversionTags={conversionTags}
+        lpData={lp}
+      />
+      
+      <div className="min-h-screen">
+        {lp.sections
+          .filter(section => section.active)
+          .sort((a, b) => a.order - b.order)
+          .map((section) => (
+            <RenderSection
+              key={section.id}
+              section={section}
+              accountData={lp.account}
+            />
+          ))}
+      </div>
+    </>
+  )
+}
+
+// Função para buscar LP por slug
+async function getLPBySlug(slug: string): Promise<LPWithDetails | null> {
+  try {
+    const { data, error } = await DatabaseService.supabase
+      .from('lps')
+      .select(`
+        *,
+        account:accounts(*),
+        sections:lp_sections(*)
+      `)
+      .eq('slug', slug)
+      .eq('active', true)
+      .single()
+
+    if (error) throw error
+    return data
+  } catch (error) {
+    console.error('Erro ao buscar LP:', error)
+    return null
+  }
+}
+
+// Gerar metadados dinâmicos
+export async function generateMetadata({ params }: PageProps) {
+  const lp = await getLPBySlug(params.slug)
+
+  if (!lp) {
+    return {
+      title: 'Página não encontrada',
+    }
+  }
+
+  return {
+    title: lp.title,
+    description: `${lp.title} - ${lp.account.name}`,
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,118 @@
+import { DatabaseService } from '@/services/database.service'
+import Link from 'next/link'
+import type { Database } from '@/types/database'
+
+type LPWithAccount = Database['public']['Tables']['lps']['Row'] & {
+  account: Database['public']['Tables']['accounts']['Row']
+}
+
+export default async function HomePage() {
+  // Buscar todas as LPs ativas
+  const lps = await getAllActiveLPs()
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <header className="bg-white shadow-sm">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+          <div className="flex justify-between items-center">
+            <div>
+              <h1 className="text-3xl font-bold text-gray-900">LP Factory</h1>
+              <p className="mt-1 text-sm text-gray-600">
+                Landing Pages de alta conversão
+              </p>
+            </div>
+            <div className="flex gap-4">
+              <Link
+                href="/client/login"
+                className="text-gray-600 hover:text-gray-900"
+              >
+                Área do Cliente
+              </Link>
+              <Link
+                href="/admin/login"
+                className="text-gray-600 hover:text-gray-900"
+              >
+                Admin
+              </Link>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {/* Main Content */}
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="text-center mb-12">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">
+            Landing Pages Disponíveis
+          </h2>
+          <p className="text-gray-600">
+            Explore nossas landing pages otimizadas para conversão
+          </p>
+        </div>
+
+        {lps.length === 0 ? (
+          <div className="text-center py-12">
+            <p className="text-gray-500">
+              Nenhuma landing page disponível no momento.
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {lps.map((lp) => (
+              <Link
+                key={lp.id}
+                href={`/${lp.slug}`}
+                className="block bg-white rounded-lg shadow hover:shadow-lg transition-shadow"
+              >
+                <div className="p-6">
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                    {lp.title}
+                  </h3>
+                  {lp.nicho && (
+                    <p className="text-sm text-gray-600 mb-2">
+                      <span className="font-medium">Nicho:</span> {lp.nicho}
+                    </p>
+                  )}
+                  {lp.objetivo && (
+                    <p className="text-sm text-gray-600 mb-4">
+                      <span className="font-medium">Objetivo:</span> {lp.objetivo}
+                    </p>
+                  )}
+                  <div className="flex justify-between items-center">
+                    <span className="text-sm text-gray-500">
+                      {lp.account.name}
+                    </span>
+                    <span className="text-orange-600 text-sm font-medium">
+                      Ver página →
+                    </span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}
+
+// Função para buscar LPs ativas
+async function getAllActiveLPs(): Promise<LPWithAccount[]> {
+  try {
+    const { data, error } = await DatabaseService.supabase
+      .from('lps')
+      .select(`
+        *,
+        account:accounts(*)
+      `)
+      .eq('active', true)
+      .order('created_at', { ascending: false })
+
+    if (error) throw error
+    return data || []
+  } catch (error) {
+    console.error('Erro ao buscar LPs:', error)
+    return []
+  }
+}

--- a/src/components/RenderSection.tsx
+++ b/src/components/RenderSection.tsx
@@ -1,0 +1,54 @@
+import dynamic from 'next/dynamic'
+import type { Database } from '@/types/database'
+
+// Importar componentes de seção dinamicamente
+const sectionComponents = {
+  header: dynamic(() => import('./sections/Header')),
+  hero: dynamic(() => import('./sections/Hero')),
+  about: dynamic(() => import('./sections/About')),
+  services: dynamic(() => import('./sections/Services')),
+  benefits: dynamic(() => import('./sections/Benefits')),
+  technology: dynamic(() => import('./sections/Technology')),
+  steps: dynamic(() => import('./sections/Steps')),
+  testimonials: dynamic(() => import('./sections/Testimonials')),
+  faq: dynamic(() => import('./sections/FAQ')),
+  gallery: dynamic(() => import('./sections/Gallery')),
+  pricing: dynamic(() => import('./sections/Pricing')),
+  contact: dynamic(() => import('./sections/Contact')),
+  ctaFinal: dynamic(() => import('./sections/CTAFinal')),
+  footer: dynamic(() => import('./sections/Footer')),
+}
+
+interface RenderSectionProps {
+  section: Database['public']['Tables']['lp_sections']['Row']
+  accountData: Database['public']['Tables']['accounts']['Row']
+}
+
+export function RenderSection({ section, accountData }: RenderSectionProps) {
+  const Component = sectionComponents[section.section_type as keyof typeof sectionComponents]
+
+  if (!Component) {
+    console.warn(`Tipo de seção não reconhecido: ${section.section_type}`)
+    return null
+  }
+
+  // Aplicar customizações da conta (cores, logo, etc)
+  const sectionData = {
+    ...section.content_json,
+    // Aplicar paleta de cores da conta se disponível
+    ...(accountData.palette && {
+      backgroundColor: section.content_json.backgroundColor || accountData.palette.primary,
+      textColor: section.content_json.textColor || accountData.palette.secondary,
+    }),
+    // Aplicar logo da conta no header se disponível
+    ...(section.section_type === 'header' && accountData.logo_url && {
+      logo: {
+        ...section.content_json.logo,
+        src: accountData.logo_url,
+        alt: accountData.name,
+      }
+    }),
+  }
+
+  return <Component data={sectionData} />
+}

--- a/src/components/TrackingHead.tsx
+++ b/src/components/TrackingHead.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import Script from 'next/script'
+import { useEffect } from 'react'
+import type { Database } from '@/types/database'
+
+interface TrackingHeadProps {
+  trackingConfig: Database['public']['Tables']['tracking_configs']['Row'] | null
+  conversionTags: Database['public']['Tables']['lp_conversion_tags']['Row'][]
+  lpData: Database['public']['Tables']['lps']['Row']
+}
+
+export function TrackingHead({ trackingConfig, conversionTags, lpData }: TrackingHeadProps) {
+  // Tracking de conversões
+  useEffect(() => {
+    // Função para disparar eventos de conversão
+    const trackConversion = (type: string) => {
+      // Google Ads
+      const googleTag = conversionTags.find(tag => 
+        tag.tag_type === 'google_ads' && tag.event_label === type
+      )
+      if (googleTag && window.gtag) {
+        window.gtag('event', 'conversion', {
+          send_to: googleTag.tag_id,
+          value: googleTag.event_value || 1,
+          currency: 'BRL',
+        })
+      }
+
+      // Meta/Facebook
+      const metaTag = conversionTags.find(tag => 
+        tag.tag_type === 'meta_pixel' && tag.event_label === type
+      )
+      if (metaTag && window.fbq) {
+        window.fbq('track', 'Lead', {
+          value: metaTag.event_value || 1,
+          currency: 'BRL',
+        })
+      }
+
+      // Registrar no banco
+      DatabaseService.trackConversion({
+        account_id: lpData.account_id,
+        lp_id: lpData.id,
+        event_type: type,
+        value: 1,
+      }).catch(console.error)
+    }
+
+    // Adicionar listeners para botões de conversão
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement
+      const link = target.closest('a')
+      
+      if (link) {
+        const href = link.getAttribute('href')
+        if (href?.includes('wa.me') || href?.includes('whatsapp')) {
+          trackConversion('whatsapp')
+        } else if (href?.startsWith('tel:')) {
+          trackConversion('phone')
+        }
+      }
+    }
+
+    // Adicionar listener para formulários
+    const handleSubmit = (e: Event) => {
+      trackConversion('form')
+    }
+
+    document.addEventListener('click', handleClick)
+    document.querySelectorAll('form').forEach(form => {
+      form.addEventListener('submit', handleSubmit)
+    })
+
+    // Tracking de pageview
+    DatabaseService.trackAnalytics({
+      account_id: lpData.account_id,
+      lp_id: lpData.id,
+      event_name: 'pageview',
+      properties: {
+        referrer: document.referrer,
+        url: window.location.href,
+      }
+    }).catch(console.error)
+
+    return () => {
+      document.removeEventListener('click', handleClick)
+      document.querySelectorAll('form').forEach(form => {
+        form.removeEventListener('submit', handleSubmit)
+      })
+    }
+  }, [conversionTags, lpData])
+
+  if (!trackingConfig) return null
+
+  return (
+    <>
+      {/* Google Analytics 4 */}
+      {trackingConfig.ga4_id && (
+        <>
+          <Script
+            strategy="afterInteractive"
+            src={`https://www.googletagmanager.com/gtag/js?id=${trackingConfig.ga4_id}`}
+          />
+          <Script
+            id="ga4-script"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${trackingConfig.ga4_id}');
+              `,
+            }}
+          />
+        </>
+      )}
+
+      {/* Meta Pixel */}
+      {trackingConfig.meta_pixel_id && (
+        <Script
+          id="meta-pixel"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `
+              !function(f,b,e,v,n,t,s)
+              {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+              n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+              if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+              n.queue=[];t=b.createElement(e);t.async=!0;
+              t.src=v;s=b.getElementsByTagName(e)[0];
+              s.parentNode.insertBefore(t,s)}(window, document,'script',
+              'https://connect.facebook.net/en_US/fbevents.js');
+              fbq('init', '${trackingConfig.meta_pixel_id}');
+              fbq('track', 'PageView');
+            `,
+          }}
+        />
+      )}
+
+      {/* Google Ads Global Tag */}
+      {trackingConfig.google_ads_global_tag && (
+        <Script
+          id="google-ads"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: trackingConfig.google_ads_global_tag,
+          }}
+        />
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- list all available landing pages on `/`
- render landing pages by slug with dynamic metadata
- track visits and conversions on each landing page
- render sections dynamically based on page data

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a8af4611c8329a22f4decc2d3a3ab