### PR TITLE
Update rendering and service exports

### DIFF
--- a/src/components/RenderSection.tsx
+++ b/src/components/RenderSection.tsx
@@ -1,7 +1,6 @@
 import dynamic from 'next/dynamic'
 import type { Database } from '@/types/database'
 
-// Importar componentes de seção dinamicamente
 const sectionComponents = {
   header: dynamic(() => import('./sections/Header')),
   hero: dynamic(() => import('./sections/Hero')),
@@ -32,18 +31,15 @@ export function RenderSection({ section, accountData }: RenderSectionProps) {
     return null
   }
 
-  // Aplicar customizações da conta (cores, logo, etc)
   const sectionData = {
-    ...section.content_json,
-    // Aplicar paleta de cores da conta se disponível
+    ...(section.content_json as any || {}),
     ...(accountData.palette && {
-      backgroundColor: section.content_json.backgroundColor || accountData.palette.primary,
-      textColor: section.content_json.textColor || accountData.palette.secondary,
+      backgroundColor: (section.content_json as any)?.backgroundColor || (accountData.palette as any)?.primary,
+      textColor: (section.content_json as any)?.textColor || (accountData.palette as any)?.secondary,
     }),
-    // Aplicar logo da conta no header se disponível
     ...(section.section_type === 'header' && accountData.logo_url && {
       logo: {
-        ...section.content_json.logo,
+        ...(section.content_json as any)?.logo,
         src: accountData.logo_url,
         alt: accountData.name,
       }

--- a/src/services/database.service.ts
+++ b/src/services/database.service.ts
@@ -355,6 +355,6 @@ export const DatabaseService = {
     return data;
   },
 
-  // Expor o cliente Supabase para uso direto quando necessário
+  // Expor cliente Supabase
   supabase,
 };


### PR DESCRIPTION
## Summary
- use optional chaining when preparing section data in RenderSection
- shorten Supabase export comment in service

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_688adbf8ac008329bc355bfbcf659372