### PR TITLE
Implement homepage management

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "tailwind-merge": "^2.3.0",
     "lucide-react": "^0.263.1",
     "@supabase/supabase-js": "^2.39.0",
-    "@supabase/auth-helpers-nextjs": "^0.8.7"
+    "@supabase/auth-helpers-nextjs": "^0.8.7",
+    "@headlessui/react": "^1.7.17"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/components/client/ChangeHomepageModal.tsx
+++ b/src/components/client/ChangeHomepageModal.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { Fragment, useState } from 'react'
+import { Dialog, Transition } from '@headlessui/react'
+import type { Database } from '@/types/database'
+
+type LP = Database['public']['Tables']['lps']['Row']
+
+interface ChangeHomepageModalProps {
+  isOpen: boolean
+  onClose: () => void
+  lps: LP[]
+  currentHomepageId: string | null
+  onSelectHomepage: (lpId: string) => Promise<void>
+}
+
+export function ChangeHomepageModal({
+  isOpen,
+  onClose,
+  lps,
+  currentHomepageId,
+  onSelectHomepage
+}: ChangeHomepageModalProps) {
+  const [selectedId, setSelectedId] = useState<string | null>(currentHomepageId)
+  const [loading, setLoading] = useState(false)
+
+  const handleConfirm = async () => {
+    if (!selectedId) return
+    
+    setLoading(true)
+    try {
+      await onSelectHomepage(selectedId)
+      onClose()
+    } catch (error) {
+      console.error('Erro ao definir homepage:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black bg-opacity-25" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+                <Dialog.Title
+                  as="h3"
+                  className="text-lg font-medium leading-6 text-gray-900"
+                >
+                  Escolher Homepage
+                </Dialog.Title>
+                
+                <div className="mt-4">
+                  <p className="text-sm text-gray-500 mb-4">
+                    Selecione qual Landing Page será exibida como página inicial do seu site.
+                  </p>
+                  
+                  <div className="space-y-2 max-h-60 overflow-y-auto">
+                    {lps.map((lp) => (
+                      <label
+                        key={lp.id}
+                        className={`flex items-center p-3 rounded-lg border cursor-pointer transition-colors ${
+                          selectedId === lp.id
+                            ? 'border-orange-500 bg-orange-50'
+                            : 'border-gray-200 hover:bg-gray-50'
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="homepage"
+                          value={lp.id}
+                          checked={selectedId === lp.id}
+                          onChange={(e) => setSelectedId(e.target.value)}
+                          className="text-orange-600 focus:ring-orange-500"
+                        />
+                        <div className="ml-3 flex-1">
+                          <p className="text-sm font-medium text-gray-900">
+                            {lp.title}
+                          </p>
+                          <p className="text-xs text-gray-500">
+                            /{lp.slug}
+                          </p>
+                        </div>
+                        {lp.id === currentHomepageId && (
+                          <span className="text-xs text-green-600 font-medium">
+                            Atual
+                          </span>
+                        )}
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="mt-6 flex gap-3 justify-end">
+                  <button
+                    type="button"
+                    className="inline-flex justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                    onClick={onClose}
+                    disabled={loading}
+                  >
+                    Cancelar
+                  </button>
+                  <button
+                    type="button"
+                    className="inline-flex justify-center rounded-md border border-transparent bg-orange-600 px-4 py-2 text-sm font-medium text-white hover:bg-orange-700 disabled:opacity-50"
+                    onClick={handleConfirm}
+                    disabled={!selectedId || loading || selectedId === currentHomepageId}
+                  >
+                    {loading ? 'Salvando...' : 'Confirmar'}
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}

--- a/src/components/client/HomepageCard.tsx
+++ b/src/components/client/HomepageCard.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import type { Database } from '@/types/database'
+
+type LP = Database['public']['Tables']['lps']['Row']
+
+interface HomepageCardProps {
+  currentHomepage: LP | null
+  onChangeHomepage: () => void
+}
+
+export function HomepageCard({ currentHomepage, onChangeHomepage }: HomepageCardProps) {
+  return (
+    <div className="bg-white overflow-hidden shadow-lg rounded-lg border-2 border-orange-500">
+      <div className="px-6 py-4 bg-orange-50">
+        <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+          <span className="text-2xl">🏠</span>
+          Sua Homepage Atual
+        </h3>
+      </div>
+      
+      <div className="p-6">
+        {currentHomepage ? (
+          <div className="space-y-4">
+            <div className="flex items-start justify-between">
+              <div>
+                <h4 className="text-xl font-semibold text-gray-900">
+                  {currentHomepage.title}
+                </h4>
+                <p className="text-sm text-gray-600 mt-1">
+                  /{currentHomepage.slug}
+                </p>
+              </div>
+              <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                Homepage Ativa
+              </span>
+            </div>
+            
+            <div className="flex gap-3">
+              <Link
+                href={`/${currentHomepage.slug}`}
+                target="_blank"
+                className="text-sm text-orange-600 hover:text-orange-700 font-medium"
+              >
+                Ver página →
+              </Link>
+              <button
+                onClick={onChangeHomepage}
+                className="text-sm text-gray-600 hover:text-gray-700 font-medium"
+              >
+                Alterar homepage
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="text-center py-8">
+            <p className="text-gray-500 mb-4">
+              Nenhuma homepage definida
+            </p>
+            <button
+              onClick={onChangeHomepage}
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-orange-600 hover:bg-orange-700"
+            >
+              Definir Homepage
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/services/database.service.ts
+++ b/src/services/database.service.ts
@@ -145,6 +145,28 @@ export const DatabaseService = {
     return data;
   },
 
+  async setLPAsHomepage(accountId: string, lpId: string) {
+    const { error } = await supabase.rpc('set_lp_as_homepage', {
+      p_account_id: accountId,
+      p_lp_id: lpId,
+    });
+
+    if (error) throw error;
+    return { success: true };
+  },
+
+  async getHomepageLP(accountId: string) {
+    const { data, error } = await supabase
+      .from('lps')
+      .select('*')
+      .eq('account_id', accountId)
+      .eq('is_homepage', true)
+      .single();
+
+    if (error && error.code !== 'PGRST116') throw error;
+    return data;
+  },
+
   // LP Sections
   async getLPSections(lpId: string) {
     const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- add new database service methods for homepage management
- show current homepage and allow setting it via modal
- include homepage card and modal components
- update dashboard to manage homepage
- add `@headlessui/react` dependency

## Testing
- `npm run format` *(fails: prettier not installed)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688b43d249008329a2bc873d6c35cbbb