### PR TITLE
Add utilities for section editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "@supabase/supabase-js": "^2.39.0",
     "@supabase/auth-helpers-nextjs": "^0.8.7",
     "@headlessui/react": "^1.7.17",
-    "@heroicons/react": "^2.0.18"
+    "@heroicons/react": "^2.0.18",
+    "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/sortable": "^7.0.2",
+    "@dnd-kit/utilities": "^3.2.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/client/(protected)/lps/page.tsx
+++ b/src/app/client/(protected)/lps/page.tsx
@@ -176,6 +176,12 @@ export default function ClientLPsPage() {
                           >
                             Editar
                           </Link>
+                          <Link
+                            href={`/client/lps/${lp.id}/sections`}
+                            className="text-blue-600 hover:text-blue-900 mr-4"
+                          >
+                            Seções
+                          </Link>
                           <button
                             onClick={() => handleDuplicate(lp)}
                             className="text-gray-600 hover:text-gray-900 mr-4"

--- a/src/lib/sectionSchemas.ts
+++ b/src/lib/sectionSchemas.ts
@@ -204,6 +204,261 @@ export function getSectionFields(sectionType: string): SectionField[] {
         type: 'color',
       },
     ],
+    benefits: [
+      {
+        name: 'title',
+        label: 'Título',
+        type: 'text',
+        required: true,
+      },
+      {
+        name: 'backgroundColor',
+        label: 'Cor de Fundo',
+        type: 'color',
+      },
+      {
+        name: 'textColor',
+        label: 'Cor do Texto',
+        type: 'color',
+      },
+    ],
+
+    steps: [
+      {
+        name: 'title',
+        label: 'Título',
+        type: 'text',
+        required: true,
+      },
+      {
+        name: 'button.text',
+        label: 'Texto do Botão',
+        type: 'text',
+        path: ['button', 'text'],
+        required: true,
+      },
+      {
+        name: 'button.href',
+        label: 'Link do Botão',
+        type: 'url',
+        path: ['button', 'href'],
+        required: true,
+      },
+    ],
+
+    testimonials: [
+      {
+        name: 'title',
+        label: 'Título',
+        type: 'text',
+        required: true,
+      },
+      {
+        name: 'backgroundColor',
+        label: 'Cor de Fundo',
+        type: 'color',
+      },
+      {
+        name: 'textColor',
+        label: 'Cor do Texto',
+        type: 'color',
+      },
+    ],
+
+    faq: [
+      {
+        name: 'title',
+        label: 'Título',
+        type: 'text',
+        required: true,
+      },
+      {
+        name: 'backgroundColor',
+        label: 'Cor de Fundo',
+        type: 'color',
+      },
+      {
+        name: 'textColor',
+        label: 'Cor do Texto',
+        type: 'color',
+      },
+    ],
+
+    contact: [
+      {
+        name: 'title',
+        label: 'Título',
+        type: 'text',
+        required: true,
+      },
+      {
+        name: 'subtitle',
+        label: 'Subtítulo',
+        type: 'text',
+      },
+      {
+        name: 'formAction',
+        label: 'URL de Ação do Formulário',
+        type: 'url',
+        required: true,
+        helper: 'Para onde o formulário será enviado',
+      },
+      {
+        name: 'submitButton.text',
+        label: 'Texto do Botão de Envio',
+        type: 'text',
+        path: ['submitButton', 'text'],
+        required: true,
+      },
+    ],
+
+    pricing: [
+      {
+        name: 'title',
+        label: 'Título',
+        type: 'text',
+        required: true,
+      },
+      {
+        name: 'subtitle',
+        label: 'Subtítulo',
+        type: 'text',
+      },
+      {
+        name: 'backgroundColor',
+        label: 'Cor de Fundo',
+        type: 'color',
+      },
+      {
+        name: 'textColor',
+        label: 'Cor do Texto',
+        type: 'color',
+      },
+    ],
+
+    gallery: [
+      {
+        name: 'title',
+        label: 'Título',
+        type: 'text',
+        required: true,
+      },
+      {
+        name: 'subtitle',
+        label: 'Subtítulo',
+        type: 'text',
+      },
+    ],
+
+    technology: [
+      {
+        name: 'title',
+        label: 'Título',
+        type: 'text',
+        required: true,
+      },
+      {
+        name: 'image.src',
+        label: 'URL da Imagem',
+        type: 'url',
+        path: ['image', 'src'],
+        required: true,
+      },
+      {
+        name: 'image.alt',
+        label: 'Texto Alternativo da Imagem',
+        type: 'text',
+        path: ['image', 'alt'],
+        required: true,
+      },
+      {
+        name: 'button.text',
+        label: 'Texto do Botão',
+        type: 'text',
+        path: ['button', 'text'],
+        required: true,
+      },
+      {
+        name: 'button.href',
+        label: 'Link do Botão',
+        type: 'url',
+        path: ['button', 'href'],
+        required: true,
+      },
+    ],
+
+    ctaFinal: [
+      {
+        name: 'title',
+        label: 'Título',
+        type: 'text',
+        required: true,
+      },
+      {
+        name: 'subtitle',
+        label: 'Subtítulo',
+        type: 'text',
+      },
+      {
+        name: 'button.text',
+        label: 'Texto do Botão',
+        type: 'text',
+        path: ['button', 'text'],
+        required: true,
+      },
+      {
+        name: 'button.href',
+        label: 'Link do Botão',
+        type: 'url',
+        path: ['button', 'href'],
+        required: true,
+      },
+      {
+        name: 'backgroundColor',
+        label: 'Cor de Fundo',
+        type: 'color',
+      },
+      {
+        name: 'textColor',
+        label: 'Cor do Texto',
+        type: 'color',
+      },
+    ],
+
+    footer: [
+      {
+        name: 'instagram.url',
+        label: 'URL do Instagram',
+        type: 'url',
+        path: ['instagram', 'url'],
+        required: true,
+      },
+      {
+        name: 'instagram.text',
+        label: 'Texto do Instagram',
+        type: 'text',
+        path: ['instagram', 'text'],
+        required: true,
+      },
+      {
+        name: 'copyright',
+        label: 'Texto de Copyright',
+        type: 'text',
+        required: true,
+      },
+      {
+        name: 'legalLink.text',
+        label: 'Texto do Link Legal',
+        type: 'text',
+        path: ['legalLink', 'text'],
+      },
+      {
+        name: 'legalLink.href',
+        label: 'URL do Link Legal',
+        type: 'url',
+        path: ['legalLink', 'href'],
+      },
+    ],
   }
 
   return schemas[sectionType] || []

--- a/src/services/database.service.ts
+++ b/src/services/database.service.ts
@@ -271,9 +271,27 @@ export const DatabaseService = {
       .eq('id', id)
       .select()
       .single();
-    
+
     if (error) throw error;
     return data;
+  },
+
+  async updateSectionOrder(sectionId: string, newOrder: number) {
+    const { error } = await supabase
+      .from('lp_sections')
+      .update({ order: newOrder })
+      .eq('id', sectionId);
+
+    if (error) throw error;
+  },
+
+  async toggleSectionActive(sectionId: string, active: boolean) {
+    const { error } = await supabase
+      .from('lp_sections')
+      .update({ active })
+      .eq('id', sectionId);
+
+    if (error) throw error;
   },
 
   // Templates


### PR DESCRIPTION
## Summary
- extend section schema definitions for all sections
- support reordering and toggling section state in DatabaseService
- link to section editor in LP list
- add drag and drop dependencies

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing modules)*
- `npm install --no-package-lock` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688bd539cf2483298a1fd6bd63155642